### PR TITLE
Prep for release 0.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ script: "bundle exec rspec spec"
 sudo: false
 cache: bundler
 rvm:
- - 2.0
- - 2.1
  - 2.2.4
  - 2.3.0
  - jruby-9.0.4.0

--- a/lib/ld4l/foaf_rdf/version.rb
+++ b/lib/ld4l/foaf_rdf/version.rb
@@ -1,5 +1,5 @@
 module LD4L
   module FoafRDF
-    VERSION = "0.0.7"
+    VERSION = "0.1.0"
   end
 end


### PR DESCRIPTION
Includes update to support ActiveTriples 0.5, 0.6, and 0.8.2
